### PR TITLE
Added cache_dir and pass_through_pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,6 @@ matrix:
       env: CHECK=metadata_lint
     -
       env: CHECK=spec
-    -
-      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
-      rvm: 2.1.9
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Simple usage:
 Customize listen address and limit (with iptables) the IP ranges:
 
     class { '::aptcacherng':
-      listen_addresses   => 'localhost apt.example.org',
+      listen_addresses   => ['localhost apt.example.org'],
       allow_address_ipv4 => '10.182.130.0/24',
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,7 +5,7 @@
 #
 class aptcacherng::config
 (
-    String $listen_addresses,
+    Array[Stdlib::Host] $listen_addresses,
     Stdlib::Port $port,
     Stdlib::Unixpath $cache_dir,
     String $pass_through_pattern,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,7 +6,9 @@
 class aptcacherng::config
 (
     $listen_addresses,
-    $port
+    $port,
+    $cache_dir,
+    $pass_through_pattern,
 
 ) inherits aptcacherng::params
 {
@@ -18,6 +20,17 @@ class aptcacherng::config
         owner   => $::os::params::adminuser,
         group   => $::os::params::admingroup,
         mode    => '0644',
+        require => Class['aptcacherng::install'],
+        notify  => Class['aptcacherng::service'],
+    }
+
+    
+    file { 'zzz_override.conf':
+        ensure  => present,
+        owner   => $::os::params::adminuser,
+        group   => $::os::params::admingroup,
+        mode    => '0644',
+        content => "CacheDir: ${cache_dir}"
         require => Class['aptcacherng::install'],
         notify  => Class['aptcacherng::service'],
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,10 +5,10 @@
 #
 class aptcacherng::config
 (
-    $listen_addresses,
-    $port,
-    $cache_dir,
-    $pass_through_pattern,
+    String $listen_addresses,
+    Stdlib::Port $port,
+    Stdlib::Unixpath $cache_dir,
+    String $pass_through_pattern,
 
 ) inherits aptcacherng::params
 {
@@ -27,7 +27,7 @@ class aptcacherng::config
 
     file { 'zzz_override.conf':
         ensure  => present,
-        name    => $::aptcacherng::params::config_name,
+        name    => '/etc/apt-cacher-ng/zzz_override.conf',
         content => "CacheDir: ${cache_dir}",
         owner   => $::os::params::adminuser,
         group   => $::os::params::admingroup,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,7 +24,7 @@ class aptcacherng::config
         notify  => Class['aptcacherng::service'],
     }
 
-    
+
     file { 'zzz_override.conf':
         ensure  => present,
         name    => $::aptcacherng::params::config_name,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,10 +27,11 @@ class aptcacherng::config
     
     file { 'zzz_override.conf':
         ensure  => present,
+        name    => $::aptcacherng::params::config_name,
+        content => "CacheDir: ${cache_dir}",
         owner   => $::os::params::adminuser,
         group   => $::os::params::admingroup,
         mode    => '0644',
-        content => "CacheDir: ${cache_dir}"
         require => Class['aptcacherng::install'],
         notify  => Class['aptcacherng::service'],
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@
 # [*manage_monit*]
 #   Manage monit rules. Valid values are true (default) and false.
 # [*listen_addresses*]
-#   A space-separated list of IP address to listen on (see "BindAddress" in 
+#   An array of IP address or FQDN to listen on (see "BindAddress" in 
 #   apt-cacher-ng documentation). For example '0.0.0.0', 'server.domain.com' or 
 #   'localhost'. Defaults to 'localhost'
 # [*port*]
@@ -47,6 +47,7 @@
 # == Authors
 #
 # Samuli Seppänen <samuli@openvpn.net>
+# Elfranne (https://github.com/elfranne)
 #
 # == License
 #
@@ -57,7 +58,7 @@ class aptcacherng
     Boolean $manage                             = true,
     Boolean $manage_packetfilter                = true,
     Boolean $manage_monit                       = true,
-    String $listen_addresses                    = 'localhost',
+    Array[Stdlib::Host] $listen_addresses       = ['localhost'],
     Stdlib::Port $port                          = 3142,
     Stdlib::IP::Address::V4 $allow_address_ipv4 = '127.0.0.1',
     Stdlib::IP::Address::V6 $allow_address_ipv6 = '::1',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,10 @@
 # [*monitor_email*]
 #   Email address where local service monitoring software sends it's reports to. 
 #   Defaults to global variable $::servermonitor.
+# [*cache_dir*]
+#   Path to the cache. Defaults to '/var/cache/apt-cacher-ng'
+# [*pass_through_pattern*]
+#   Pattern to allow SSL repositories to bypass the cache. Defaults to '.*'
 #
 # == Examples
 #
@@ -50,14 +54,16 @@
 #
 class aptcacherng
 (
-    Boolean $manage = true,
+    Boolean $manage              = true,
     Boolean $manage_packetfilter = true,
-    Boolean $manage_monit = true,
-    $listen_addresses = 'localhost',
-    $port = 3142,
-    $allow_address_ipv4 = '127.0.0.1',
-    $allow_address_ipv6 = '::1',
-    $monitor_email = $::servermonitor
+    Boolean $manage_monit        = true,
+    $listen_addresses            = 'localhost',
+    Integer $port                = 3142,
+    $allow_address_ipv4          = '127.0.0.1',
+    $allow_address_ipv6          = '::1',
+    $monitor_email               = $::servermonitor,
+    String $cache_dir            = '/var/cache/apt-cacher-ng',
+    String $pass_through_pattern = '.*',
 )
 {
 
@@ -66,8 +72,10 @@ if $manage {
     include ::aptcacherng::install
 
     class { '::aptcacherng::config':
-        listen_addresses => $listen_addresses,
-        port             => $port,
+        listen_addresses     => $listen_addresses,
+        port                 => $port,
+        cache_dir            => $cache_dir,
+        pass_through_pattern => $pass_through_pattern,
     }
 
     include ::aptcacherng::service

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,16 +54,16 @@
 #
 class aptcacherng
 (
-    Boolean $manage              = true,
-    Boolean $manage_packetfilter = true,
-    Boolean $manage_monit        = true,
-    $listen_addresses            = 'localhost',
-    Integer $port                = 3142,
-    $allow_address_ipv4          = '127.0.0.1',
-    $allow_address_ipv6          = '::1',
-    $monitor_email               = $::servermonitor,
-    String $cache_dir            = '/var/cache/apt-cacher-ng',
-    String $pass_through_pattern = '.*',
+    Boolean $manage                             = true,
+    Boolean $manage_packetfilter                = true,
+    Boolean $manage_monit                       = true,
+    String $listen_addresses                    = 'localhost',
+    Stdlib::Port $port                          = 3142,
+    Stdlib::IP::Address::V4 $allow_address_ipv4 = '127.0.0.1',
+    Stdlib::IP::Address::V6 $allow_address_ipv6 = '::1',
+    String $monitor_email                       = $::servermonitor,
+    Stdlib::Unixpath $cache_dir                 = '/var/cache/apt-cacher-ng',
+    String $pass_through_pattern                = '.*',
 )
 {
 

--- a/manifests/packetfilter.pp
+++ b/manifests/packetfilter.pp
@@ -5,9 +5,9 @@
 #
 class aptcacherng::packetfilter
 (
-    $allow_address_ipv4,
-    $allow_address_ipv6,
-    $port
+    Stdlib::IP::Address::V4 $allow_address_ipv4,
+    Stdlib::IP::Address::V6 $allow_address_ipv6,
+    Stdlib::Port $port,
 
 ) inherits aptcacherng::params
 {

--- a/metadata.json
+++ b/metadata.json
@@ -18,6 +18,9 @@
     {
       "name": "puppetfinland/os",
       "version_requirement": ">= 0.5.6"
+    },
+    { "name": "puppetlabs/stdlib", 
+      "version_requirement": ">= 4.25.0" 
     }
   ],
   "operatingsystem_support": [

--- a/templates/acng.conf.erb
+++ b/templates/acng.conf.erb
@@ -25,7 +25,7 @@ Port:<%= @port %>
 # Default: not set, will listen on all interfaces and protocols
 #
 # BindAddress: localhost 192.168.7.254 publicNameOnMainInterface
-BindAddress: <%= @listen_addresses %>
+BindAddress: <%= @listen_addresses.join(' ') %>
 
 # The specification of another proxy which shall be used for downloads. Username 
 # and password are, and see manual for limitations.

--- a/templates/acng.conf.erb
+++ b/templates/acng.conf.erb
@@ -2,7 +2,7 @@
 # Letter case in directive names does not matter. Must be separated with colons.
 # Valid boolean values are a zero number for false, non-zero numbers for true.
 
-CacheDir: /var/cache/apt-cacher-ng
+CacheDir: <%= @cache_dir %>
 
 # set empty to disable logging
 LogDir: /var/log/apt-cacher-ng
@@ -293,6 +293,7 @@ ExTreshold: 4
 # Examples: 
 # PassThroughPattern: private-ppa\.launchpad\.net:443$ 
 # PassThroughPattern: .* # this would allow CONNECT to everything
+PassThroughPattern: <%= @pass_through_pattern %>
 
 # It's possible that an evil client requests a volatile file but does not
 # retrieve the response and keeps the connection effectively stuck over


### PR DESCRIPTION
Set the location of the cache directory where all the deb will be stored.
Set the pass_through_pattern to allow SSL repo to bypass the cache.
